### PR TITLE
ci: grant contents:write so benchmark push stops failing CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,14 @@
 
 name: Go
 
+# The benchmark-action (auto-push) and coverage-badge steps push to the
+# gh-pages / current branch, so the default GITHUB_TOKEN needs contents
+# write access. Without this the "Store benchmark result" step fails with
+# `git exit code 128` on every PR.
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Root cause of all lazywritercache CI failures: the `Store benchmark result` step (benchmark-action auto-push to gh-pages) fails with `git exit code 128` on PRs because the workflow has no `permissions:` block, so GITHUB_TOKEN is read-only. Build, tests, and benchmarks all pass. Add `permissions: contents:write` (+ pull-requests:write).